### PR TITLE
chore: updated rusb dependency to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ documentation = "https://github.com/rogerioadris/rust-usbtmc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusb = "0.8.0"
+rusb = "0.9.0"
 byteorder = "1.4"


### PR DESCRIPTION
I updated the `rusb` dependency, as I need the newer version in my project.