### PR TITLE
Feat: multiple device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ const VID: u16 = 0x0699; // Vendor
 const PID: u16 = 0x0368; // Product
 
 // Bus and Device settings of the first instrument
-const FIRST_BUS: u8 = 0x01; // Bus
-const FIRST_ADDRESS: u8 = 0x01; // Device
+const FIRST_BUS: u8 = 0x01;
+const FIRST_ADDRESS: u8 = 0x01;
 
 // Bus and Device settings of the second instrument
-const SECOND_BUS: u8 = 0x01; // Bus
-const SECOND_ADDRESS: u8 = 0x01; // Device
+const SECOND_BUS: u8 = 0x03;
+const SECOND_ADDRESS: u8 = 0x02;
 
 fn main() {
     // Select first specific Instrument.
@@ -42,11 +42,11 @@ fn main() {
     // Select second specific Instrument.
     let mut instr2 = Instrument::new_filtered(VID, PID, SECOND_BUS, SECOND_ADDRESS);
 
-    // Command Osciloscope
+    // Execute commands on the first Instrument
     instr1.write("SELECT:CH1 1").unwrap();
     println!("Ask: {}", instr1.ask("*IDN?").unwrap());
 
-    // Command Osciloscope
+    // Execute commands on the second Instrument
     instr2.write("SELECT:CH2 1").unwrap();
     println!("Ask: {}", instr2.ask("*IDN?").unwrap());
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rust USBTMC
 
-Exemplo de uso
+## Single instrument
 
 ```rust
 use rust_usbtmc::instrument::Instrument;
@@ -14,5 +14,40 @@ fn main() {
     // Command Osciloscope
     instr.write("SELECT:CH1 1").unwrap();
     println!("Ask: {}", instr.ask("*IDN?").unwrap());
+}
+```
+
+## Multiple instruments
+
+You are able to connect to multiple devices with same `VID` and `PID` by filtering them on `Bus` and `Device` entries from `lsusb`.
+
+```rust
+use rust_usbtmc::instrument::Instrument;
+
+const VID: u16 = 0x0699; // Vendor
+const PID: u16 = 0x0368; // Product
+
+// Bus and Device settings of the first instrument
+const FIRST_BUS: u8 = 0x01; // Bus
+const FIRST_ADDRESS: u8 = 0x01; // Device
+
+// Bus and Device settings of the second instrument
+const SECOND_BUS: u8 = 0x01; // Bus
+const SECOND_ADDRESS: u8 = 0x01; // Device
+
+fn main() {
+    // Select first specific Instrument.
+    let mut instr1 = Instrument::new_filtered(VID, PID, FIRST_BUS, FIRST_ADDRESS);
+
+    // Select second specific Instrument.
+    let mut instr2 = Instrument::new_filtered(VID, PID, SECOND_BUS, SECOND_ADDRESS);
+
+    // Command Osciloscope
+    instr1.write("SELECT:CH1 1").unwrap();
+    println!("Ask: {}", instr1.ask("*IDN?").unwrap());
+
+    // Command Osciloscope
+    instr2.write("SELECT:CH2 1").unwrap();
+    println!("Ask: {}", instr2.ask("*IDN?").unwrap());
 }
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,25 @@ use std::time::Instant;
 const VID: u16 = 0x0699;
 const PID: u16 = 0x0368;
 
+const BUS: u8 = 0x01;
+const ADDRESS: u8 = 0x01;
+
 fn main() {
-    let mut instr = Instrument::new(VID, PID);
+    // Single device
+    let mut instr_single = Instrument::new(VID, PID);
+    let start = Instant::now();
+    instr_single.write("SELECT:CH1 1").unwrap();
+    println!("Ask: {}", instr_single.ask("*IDN?").unwrap());
+
+    let duration = start.elapsed();
+    println!("Time elapsed is: {:?}", duration);
+
+    // Multiple devices
+    let mut instr_multiple = Instrument::new_filtered(VID, PID, BUS, ADDRESS);
 
     let start = Instant::now();
-    instr.write("SELECT:CH1 1").unwrap();
-    println!("Ask: {}", instr.ask("*IDN?").unwrap());
+    instr_multiple.write("SELECT:CH1 1").unwrap();
+    println!("Ask: {}", instr_multiple.ask("*IDN?").unwrap());
 
     let duration = start.elapsed();
     println!("Time elapsed is: {:?}", duration);


### PR DESCRIPTION
I've added additional filtering to the `open_device` function.

I've added a new function to the `Instrument` struct, which allows you to filter the exact device you want.

You specify your device using `BUS` and `ADDRESS`, both present in the output of `lsusb`, named `Bus` and `Device`.
(I can't figure out any other way of specifying the specific instrument)

Closes #1.